### PR TITLE
Adapt to Spotify API changes: use position-based scoring

### DIFF
--- a/api/artists-ranking.js
+++ b/api/artists-ranking.js
@@ -55,9 +55,12 @@ const SEARCH_QUERIES = [
     'pop', 'rock', 'hip hop', 'trap', 'reggae',
     'dance', 'country', 'band', 'legend', 'star'
 ];
-const SEARCH_LIMIT = 50;
-const SEARCH_OFFSETS = [0, 50, 100];
+// Spotify Development Mode: max limit is now 10 (reduced from 50)
+const SEARCH_LIMIT = 10;
+const SEARCH_OFFSETS = [0, 10, 20];
 const RANKING_SIZE = 100;
+// Maximum absolute position used for scoring (offset + index)
+const MAX_POSITION = Math.max(...SEARCH_OFFSETS) + SEARCH_LIMIT;
 
 let cachedRanking = null;
 let lastCacheTime = 0;
@@ -79,36 +82,38 @@ async function getArtistsRanking() {
             const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=${SEARCH_LIMIT}&offset=${offset}`;
             searchPromises.push(
                 axios.get(url, { headers })
-                    .then(res => res.data.artists.items || [])
-                    .catch(() => [])
+                    .then(res => ({ items: res.data.artists.items || [], offset }))
+                    .catch(() => ({ items: [], offset }))
             );
         }
     }
 
     const results = await Promise.all(searchPromises);
 
-    for (const group of results) {
-        for (const artist of group) {
-            if (
-                artist?.id &&
-                artist?.name &&
-                artist?.followers?.total &&
-                typeof artist.popularity === 'number' &&
-                artist?.images?.[0]?.url
-            ) {
-                allArtistsMap.set(artist.id, {
-                    id: artist.id,
-                    name: artist.name,
-                    followers: artist.followers.total,
-                    popularity: artist.popularity,
-                    imageUrl: artist.images[0].url
-                });
+    // Rank artists by search-result position score.
+    // popularity and followers are no longer available in Development Mode
+    // (removed per Spotify's February 2026 API changes).
+    for (const { items, offset } of results) {
+        items.forEach((artist, index) => {
+            if (artist?.id && artist?.name && artist?.images?.[0]?.url) {
+                // Artists appearing earlier in search results score higher
+                const positionScore = MAX_POSITION - (offset + index);
+                if (allArtistsMap.has(artist.id)) {
+                    allArtistsMap.get(artist.id).score += positionScore;
+                } else {
+                    allArtistsMap.set(artist.id, {
+                        id: artist.id,
+                        name: artist.name,
+                        imageUrl: artist.images[0].url,
+                        score: positionScore
+                    });
+                }
             }
-        }
+        });
     }
 
     const uniqueArtists = Array.from(allArtistsMap.values());
-    uniqueArtists.sort((a, b) => b.popularity - a.popularity);
+    uniqueArtists.sort((a, b) => b.score - a.score);
 
     cachedRanking = uniqueArtists.slice(0, RANKING_SIZE);
     lastCacheTime = Date.now();
@@ -153,8 +158,6 @@ app.get('/api/search-artist', async (req, res) => {
         res.json({
             id: artist.id,
             name: artist.name,
-            popularity: artist.popularity ?? 0,
-            followers: artist.followers?.total ?? 0,
             imageUrl: artist.images?.[0]?.url || 'https://via.placeholder.com/150',
             rankInTop100: rank > 0 ? rank : -1
         });

--- a/api/search-artist.js
+++ b/api/search-artist.js
@@ -59,8 +59,6 @@ export default async function handler(req, res) {
     res.json({
       id: artist.id,
       name: artist.name,
-      popularity: artist.popularity ?? 0,
-      followers: artist.followers?.total ?? 0,
       imageUrl: artist.images?.[0]?.url || 'https://via.placeholder.com/150',
       rankInTop100: -1 // Let frontend compare with list if needed
     });

--- a/public/script.js
+++ b/public/script.js
@@ -207,8 +207,6 @@ function displayArtists(artists) {
             <img src="${artist.imageUrl}" alt="${artist.name}" class="artist-image" loading="lazy">
             <div class="artist-info">
                 <h3 class="artist-name">${artist.name}</h3>
-                <p>Popularity: <strong style="color: var(--primary-color);">${artist.popularity}/100</strong></p>
-                <p>Followers: <strong style="color: var(--accent-color);">${artist.followers.toLocaleString()}</strong></p>
             </div>
         `;
         
@@ -320,8 +318,6 @@ async function searchArtist() {
                 <img src="${artist.imageUrl}" alt="${artist.name}" class="artist-image">
                 <div class="artist-info">
                     <h3 class="artist-name">${artist.name}</h3>
-                    <p>Popularity: <strong style="color: var(--primary-color);">${artist.popularity}/100</strong></p>
-                    <p>Followers: <strong style="color: var(--accent-color);">${artist.followers.toLocaleString()}</strong></p>
                     ${rankText}
                 </div>
             `;


### PR DESCRIPTION
## Summary
This PR updates the artist ranking system to adapt to Spotify's February 2026 API changes that removed access to popularity and followers data in Development Mode. The ranking algorithm now uses search result position as the primary scoring metric instead.

## Key Changes
- **Reduced search limits**: Lowered `SEARCH_LIMIT` from 50 to 10 and adjusted `SEARCH_OFFSETS` accordingly to comply with Development Mode restrictions
- **Position-based scoring**: Replaced popularity/followers-based ranking with a position score calculated from search result position (earlier results score higher)
- **Removed deprecated fields**: Eliminated `popularity` and `followers` from API responses and frontend display across all artist endpoints
- **Simplified artist data model**: Artist objects now only contain `id`, `name`, `imageUrl`, and `score` (or `rankInTop100` in responses)
- **Updated frontend display**: Removed popularity and followers information from artist cards in both ranking and search results

## Implementation Details
- Added `MAX_POSITION` constant to normalize position scores across all search result batches
- Modified search result handling to track offset with each batch of results
- Artists appearing in multiple search queries accumulate position scores
- Sorting now uses the aggregated position score instead of popularity metric

https://claude.ai/code/session_011gavSo1N53a4EiFF9173sL