### PR TITLE
Fix search rank lookup missing artists due to single-candidate lookup

### DIFF
--- a/api/artists-ranking.js
+++ b/api/artists-ranking.js
@@ -143,23 +143,43 @@ app.get('/api/search-artist', async (req, res) => {
     try {
         const token = await getSpotifyAccessToken();
 
-        const searchRes = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(name)}&type=artist&limit=1`, {
+        const searchRes = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(name)}&type=artist&limit=5`, {
             headers: { Authorization: `Bearer ${token}` }
         });
 
         const json = await searchRes.json();
-        const artist = json.artists?.items?.[0];
+        const candidates = json.artists?.items || [];
 
-        if (!artist) return res.status(404).json({ message: 'Artist not found' });
+        if (!candidates.length) return res.status(404).json({ message: 'Artist not found' });
 
         const topArtists = await getArtistsRanking();
-        const rank = topArtists.findIndex(a => a.id === artist.id) + 1;
+
+        // Pick the highest-ranked candidate among the search results (by Spotify ID)
+        let bestArtist = candidates[0];
+        let bestRank = Infinity;
+
+        for (const candidate of candidates) {
+            if (!candidate?.id) continue;
+            const rankIdx = topArtists.findIndex(a => a.id === candidate.id);
+            if (rankIdx !== -1 && rankIdx + 1 < bestRank) {
+                bestArtist = candidate;
+                bestRank = rankIdx + 1;
+            }
+        }
+
+        // Fallback: case-insensitive name match in ranking (handles duplicate artist profiles)
+        if (bestRank === Infinity) {
+            const nameIdx = topArtists.findIndex(
+                a => a.name.toLowerCase() === candidates[0].name.toLowerCase()
+            );
+            if (nameIdx !== -1) bestRank = nameIdx + 1;
+        }
 
         res.json({
-            id: artist.id,
-            name: artist.name,
-            imageUrl: artist.images?.[0]?.url || 'https://via.placeholder.com/150',
-            rankInTop100: rank > 0 ? rank : -1
+            id: bestArtist.id,
+            name: bestArtist.name,
+            imageUrl: bestArtist.images?.[0]?.url || 'https://via.placeholder.com/150',
+            rankInTop100: bestRank < Infinity ? bestRank : -1
         });
     } catch (err) {
         console.error('❌ Search API Error:', err);

--- a/public/script.js
+++ b/public/script.js
@@ -300,7 +300,7 @@ async function searchArtist() {
             artistCard.className = 'artist-item searched-artist'; // Use existing styling + new class
 
             let rankText = '';
-            if (artist.rankInTop100 && artist.rankInTop100 !== -1) { // Check for truthiness and -1
+            if (artist.rankInTop100 > 0) {
                 rankText = `<span class="rank-badge">Rank #${artist.rankInTop100}</span>`;
 
                 // Highlight the artist in the main list if found


### PR DESCRIPTION
When searching a short query like "Taylor", Spotify's top result isn't always the most-ranked artist in the app (e.g. returns a lesser-known "Taylor" instead of Taylor Swift). The search now fetches up to 5 candidates, picks the one with the best rank by ID, and falls back to a case-insensitive name match for duplicate-profile edge cases. Frontend rank check tightened to `> 0` instead of the fragile truthiness + !== -1 double condition.

https://claude.ai/code/session_011gavSo1N53a4EiFF9173sL